### PR TITLE
Update ring order during build, have adopt as inner ring, hold as outer

### DIFF
--- a/radar.json
+++ b/radar.json
@@ -1,30 +1,9 @@
 [
   {
-    "name": "hapi",
-    "quadrant": "Languages and Frameworks",
-    "ring": "Hold",
-    "description": "<p>Synapse has used <a href=\"https://hapi.dev/\">hapi</a> for close to a decade. We originally adopted hapi for its strong culture, lightweight api, and security features. One important aspect of hapi has always been that it has no external dependencies at all. Hapi is and has always been completely isolated from <a href=\"https://circleci.com/blog/secure-software-supply-chain/?utm_source=google&amp;utm_medium=sem&amp;utm_campaign=sem-google-dg--uscan-en-dsa-tROAS-auth-nb&amp;utm_term=g_-_c__dsa_&amp;utm_content=&amp;gclid=CjwKCAjw_MqgBhAGEiwAnYOAemTlrPWDKv0v_kNRMIPVVLv6SDF925rd87LlZA6FXutlSeTpajtu-RoCca0QAvD_BwE\">supply chain</a> security issues.</p>\n<p>However, we have moved the hapi blip into our &quot;Hold&quot; ring for two reasons. One is that as of a couple of years ago we've rapidly adopted typescript. Working with hapi in typescript has been painful and we started to prefer typescript native frameworks. Our architectural preferences have also grown somewhat in that timeframe and we have grown to prefer a stronger modularization paradigm than hapi's plugins. We have especially fallen out of love with the convention in the hapi community to mutate the server object in order to pass around plugins and other dependencies. Hapi will probably always have a place at Synapse, but we are no longer starting new work with this framework.</p>\n",
-    "isNew": "TRUE"
-  },
-  {
     "name": "NestJS",
     "quadrant": "Languages and Frameworks",
     "ring": "Adopt",
     "description": "<p>Most of the work Synapse does can most responsibly be done with the <a href=\"https://www.youtube.com/watch?v=5OjqD-ow8GE\">modular monolith</a> architecture pattern, and we have been using <a href=\"https://nestjs.com/\">NestJS</a> to build these monoliths. Nest is a fairly heavy weight framework, which makes it an unusual choice for Synapse, but it has a very good module system, it's very popular, and it's well designed.</p>\n<p>Because it has a bigger footprint than the frameworks we've historically used it will be important to stricly define the boundaries between the parts of our code that are allowed to know about the framework, and the parts that aren't.</p>\n",
-    "isNew": "TRUE"
-  },
-  {
-    "name": "Next.js",
-    "quadrant": "Languages and Frameworks",
-    "ring": "Trial",
-    "description": "<p><a href=\"https://nextjs.org/\">Next.js</a> is a popular React framework that offers a handful of nice features. For extremely dynamic sites and content Next.js offers a simplified framework for delivering React apps with server side rendering (SSR). SSR is becoming more popular as a default for single page applications because of the performance and SEO improvements. Some teams are even leveraging their SSR apps to open up api and data fetching design options. For example, you can access a database from your Next.js code and eliminate the need for backend frameworks.</p>\n<p>SSR frameworks are becoming ubiquitous. Fewer people are familiuar with <a href=\"https://reactjs.org/docs/create-a-new-react-app.html#create-react-app\">create react app</a> and the technology involved in bundling a SPA for client side delivery and rendering. This is one of the biggest reasons to start trialing other frameworks, build tools, architectures and delivery methods.</p>\n",
-    "isNew": "TRUE"
-  },
-  {
-    "name": "Title2",
-    "quadrant": "Platforms",
-    "ring": "Hold",
-    "description": "<p>Description</p>\n",
     "isNew": "TRUE"
   },
   {
@@ -35,9 +14,30 @@
     "isNew": "TRUE"
   },
   {
+    "name": "Next.js",
+    "quadrant": "Languages and Frameworks",
+    "ring": "Trial",
+    "description": "<p><a href=\"https://nextjs.org/\">Next.js</a> is a popular React framework that offers a handful of nice features. For extremely dynamic sites and content Next.js offers a simplified framework for delivering React apps with server side rendering (SSR). SSR is becoming more popular as a default for single page applications because of the performance and SEO improvements. Some teams are even leveraging their SSR apps to open up api and data fetching design options. For example, you can access a database from your Next.js code and eliminate the need for backend frameworks.</p>\n<p>SSR frameworks are becoming ubiquitous. Fewer people are familiuar with <a href=\"https://reactjs.org/docs/create-a-new-react-app.html#create-react-app\">create react app</a> and the technology involved in bundling a SPA for client side delivery and rendering. This is one of the biggest reasons to start trialing other frameworks, build tools, architectures and delivery methods.</p>\n",
+    "isNew": "TRUE"
+  },
+  {
     "name": "Title1",
     "quadrant": "Techniques",
     "ring": "Trial",
+    "description": "<p>Description</p>\n",
+    "isNew": "TRUE"
+  },
+  {
+    "name": "hapi",
+    "quadrant": "Languages and Frameworks",
+    "ring": "Hold",
+    "description": "<p>Synapse has used <a href=\"https://hapi.dev/\">hapi</a> for close to a decade. We originally adopted hapi for its strong culture, lightweight api, and security features. One important aspect of hapi has always been that it has no external dependencies at all. Hapi is and has always been completely isolated from <a href=\"https://circleci.com/blog/secure-software-supply-chain/?utm_source=google&amp;utm_medium=sem&amp;utm_campaign=sem-google-dg--uscan-en-dsa-tROAS-auth-nb&amp;utm_term=g_-_c__dsa_&amp;utm_content=&amp;gclid=CjwKCAjw_MqgBhAGEiwAnYOAemTlrPWDKv0v_kNRMIPVVLv6SDF925rd87LlZA6FXutlSeTpajtu-RoCca0QAvD_BwE\">supply chain</a> security issues.</p>\n<p>However, we have moved the hapi blip into our &quot;Hold&quot; ring for two reasons. One is that as of a couple of years ago we've rapidly adopted typescript. Working with hapi in typescript has been painful and we started to prefer typescript native frameworks. Our architectural preferences have also grown somewhat in that timeframe and we have grown to prefer a stronger modularization paradigm than hapi's plugins. We have especially fallen out of love with the convention in the hapi community to mutate the server object in order to pass around plugins and other dependencies. Hapi will probably always have a place at Synapse, but we are no longer starting new work with this framework.</p>\n",
+    "isNew": "TRUE"
+  },
+  {
+    "name": "Title2",
+    "quadrant": "Platforms",
+    "ring": "Hold",
     "description": "<p>Description</p>\n",
     "isNew": "TRUE"
   }

--- a/src/build.js
+++ b/src/build.js
@@ -31,6 +31,6 @@ module.exports = async (opts = {dir: '', outFile: ''}) =>  {
 	const files = await getFiles(opts.dir);
 	const readData = (f) => fs.promises.readFile(`${opts.dir}/${f}`, 'utf8')
 	const results = await parse(files, readData);
-  results.sort((a, b) => RING_ORDER[a.ring] - RING_ORDER[b.ring]);
+	results.sort((a, b) => RING_ORDER[a.ring] - RING_ORDER[b.ring]);
 	await fs.promises.writeFile(opts.outFile, JSON.stringify(results, null, 2))
 }

--- a/src/build.js
+++ b/src/build.js
@@ -2,6 +2,13 @@ var MarkdownIt = require('markdown-it');
 const meta = require('markdown-it-meta')
 const fs = require('fs');
 
+// Lower RING_ORDER values are closer to the center
+const RING_ORDER = {
+  Adopt: 1,
+  Trial: 2,
+  Hold: 3,
+}
+
 const getFiles = (dir) => new Promise((resolve, reject) => {
 	fs.readdir(dir, (e, d) => {
 		if (e) reject(e);
@@ -24,5 +31,6 @@ module.exports = async (opts = {dir: '', outFile: ''}) =>  {
 	const files = await getFiles(opts.dir);
 	const readData = (f) => fs.promises.readFile(`${opts.dir}/${f}`, 'utf8')
 	const results = await parse(files, readData);
+  results.sort((a, b) => RING_ORDER[a.ring] - RING_ORDER[b.ring]);
 	await fs.promises.writeFile(opts.outFile, JSON.stringify(results, null, 2))
 }

--- a/src/build.js
+++ b/src/build.js
@@ -4,9 +4,9 @@ const fs = require('fs');
 
 // Lower RING_ORDER values are closer to the center
 const RING_ORDER = {
-  Adopt: 1,
-  Trial: 2,
-  Hold: 3,
+	Adopt: 1,
+	Trial: 2,
+	Hold: 3,
 }
 
 const getFiles = (dir) => new Promise((resolve, reject) => {


### PR DESCRIPTION
From: https://github.com/thoughtworks/build-your-own-radar
> Note: The quadrants of the radar, and the order of the rings inside the radar will be drawn in the order they appear in your data.

This just sorts the json to put things we adopt near the middle and things we hold on the outside.